### PR TITLE
feat: /list-agents alias for /peers (Claude Code compatible)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# opencode-plugin-peers
+
+Cross-session messaging plugin for opencode: independent instances on the same machine discover each other and exchange plain-text messages. Modeled after Claude Code's cross-session messaging.
+
+## Commands
+
+- `npm run build` — tsc → `dist/`
+- `npm test` — build + `node --test tests/*.test.mjs` (must be all green before any PR)
+- `npm run typecheck`
+- `npm run dry-run` — `npm publish --dry-run`
+
+## Architecture notes
+
+- One registry file per instance in `$XDG_DATA_HOME/opencode-plugin-peers/peers.d/` (0600, atomic write, 10s heartbeat; alive = fresh heartbeat + live PID + `/health` probe).
+- Each instance runs a 127.0.0.1-only inbox listener (random port, bearer token from its registry file). Peers never call each other's opencode server directly.
+- Delivery: queue while busy, flush on `session.idle` (+15s fallback sweep) via own `client.session.promptAsync` — injected messages are ordinary synthetic user messages with no privileges.
+- Plugin options arrive as the **second `Plugin` argument** (tuple form in config), not on `ctx` — keep the dual read in `src/index.ts`.
+- Modules use factory functions, not `class` + `new` (opencode's loader can break `new`).
+- Commands (`/peers*`) are intercepted in `command.execute.before`; the result is written back into the first text part so it also works headless.
+
+## Development workflow
+
+1. **Feature branch only** — never commit directly to `main`. Branch off `main`, commit there.
+2. **Local verification** — `npm test` must be fully green. Any change touching TUI or command behavior additionally requires a real OpenCode E2E (two local `opencode serve` instances driven over the HTTP API; see the verification flow in git history / README "End-to-end verification").
+3. **PR to `main`** — open a PR, merge only after verification results are in the PR description.
+4. **npm publish** — semantic version bump in `package.json`. Read the npm token from the **last line** of `/Users/wangshuai/Downloads/npm_access_token.txt`, configure it temporarily (e.g. `//registry.npmjs.org/:_authToken=...` via env or a throwaway `.npmrc`), and **never commit the token or any file containing it**. Remove temporary config after publishing.
+5. **Tag & Release** — tag the merge commit on `main` (`vX.Y.Z`), push, then `gh release create` with: changes grouped by category (Features/Fixes/Tests/Docs), the verification conclusions, and a Full Changelog link. Mark the release as **Latest**.
+
+## Gotchas
+
+- `session.idle` is not guaranteed on every opencode version — keep the fallback sweep.
+- `opencode serve` loads plugins lazily: create a session first before expecting registration.
+- When spawning background `opencode serve` processes from scripts, detach stdio (`nohup ... &` inside a subshell) or the parent hangs on the inherited pipe.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Run several opencode terminals in parallel (different repos, worktrees, or tasks
 ## Features
 
 - `list_agents` / `send_message` tools — the agent can discover peers and text them
-- `/peers`, `/peers-name`, `/peers-inbox` commands — user-side control
+- `/peers` (alias `/list-agents`, compatible with Claude Code), `/peers-name`, `/peers-inbox` commands — user-side control
 - **accept / hold / refuse** inbound gating
 - Busy sessions queue messages; delivery happens when the session goes idle (plus a 15s fallback sweep)
 - Messages are **plain text only** — no files, no shared conversation history

--- a/commands/list-agents.md
+++ b/commands/list-agents.md
@@ -1,0 +1,8 @@
+---
+description: List same-machine opencode peers you can exchange messages with (alias of /peers, compatible with Claude Code's /list-agents)
+argument-hint: ""
+---
+
+$ARGUMENTS
+
+If this command was not intercepted by the opencode-plugin-peers plugin, call the list_agents tool and show the result to the user verbatim.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-peers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cross-session messaging for opencode — let independent sessions discover and text each other, modeled after Claude Code's cross-session messaging",
   "type": "module",
   "main": "./dist/index.js",
@@ -16,6 +16,7 @@
       "import": "./dist/index.js"
     },
     "./commands/peers.md": "./commands/peers.md",
+    "./commands/list-agents.md": "./commands/list-agents.md",
     "./commands/peers-name.md": "./commands/peers-name.md",
     "./commands/peers-inbox.md": "./commands/peers-inbox.md",
     "./commands/*": "./commands/*"
@@ -74,6 +75,7 @@
     "plugin": true,
     "commands": [
       "commands/peers.md",
+      "commands/list-agents.md",
       "commands/peers-name.md",
       "commands/peers-inbox.md"
     ]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,7 +30,8 @@ export async function handlePeersCommand(
   command: string,
   args: string
 ): Promise<CommandResult> {
-  if (command === "peers") {
+  // "list-agents" is an alias of "peers", matching Claude Code's /list-agents.
+  if (command === "peers" || command === "list-agents") {
     const peers = await ctx.registry.list()
     const listing = formatPeerList(peers, ctx.getName(), ctx.selfInstanceId)
     const held = ctx.queue.held()

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,8 @@ import { handlePeersCommand } from "./commands.js"
 import { consumeCommand, createLogger, errorMessage, showToast } from "./feedback.js"
 import type { InboundPolicy, PluginConfig, ReceiveStatus } from "./types.js"
 
-const PLUGIN_VERSION = "0.1.0"
-const COMMAND_NAMES = new Set(["peers", "peers-name", "peers-inbox"])
+const PLUGIN_VERSION = "0.1.1"
+const COMMAND_NAMES = new Set(["peers", "list-agents", "peers-name", "peers-inbox"])
 
 export const PeersPlugin: Plugin = async (ctx, pluginOptions) => {
   const logger = createLogger(ctx.client)

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -108,6 +108,21 @@ test("/peers-inbox list/accept/drop flow", async () => {
   }
 })
 
+test("/list-agents is an alias of /peers", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "peers-cmd-"))
+  try {
+    const ctx = await makeCtx(dir)
+    const peers = await handlePeersCommand(ctx, "peers", "")
+    const alias = await handlePeersCommand(ctx, "list-agents", "")
+    assert.equal(alias.handled, true)
+    // identical listing body, both prefixed with the same emoji marker
+    assert.equal(alias.message, peers.message)
+    await ctx.registry.stop()
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
 test("unknown command passes through", async () => {
   const dir = await mkdtemp(join(tmpdir(), "peers-cmd-"))
   try {


### PR DESCRIPTION
## Summary
- Adds `/list-agents` as an alias of `/peers`, matching Claude Code's cross-session discovery command name
- Ships `commands/list-agents.md`, intercepts `list-agents` in `command.execute.before`, registered in package exports and `opencode.commands`
- Version bump to 0.1.1

## Verification
- Unit: 42/42 green, including a new alias-equivalence test (`/list-agents` output identical to `/peers`)
- Real OpenCode E2E (two local `opencode serve` instances, plugin loaded via project config): `/list-agents` on instance alpha listed online peer beta with directory, active session and inbound policy; stale entries correctly separated