### PR TITLE
fix: bound showToast so a missing TUI can no longer hang plugin init (0.1.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-peers",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cross-session messaging for opencode — let independent sessions discover and text each other, modeled after Claude Code's cross-session messaging",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -56,22 +56,41 @@ function toastDuration(message: string): number {
   return Math.min(12_000, 5_000 + extraLines * 1_500)
 }
 
-/** Toast feedback; silently degrades when no TUI is attached (headless). */
+/**
+ * Toast feedback; silently degrades when no TUI is attached (headless).
+ * Bounded by a timeout: with no TUI attached the /tui endpoint may never
+ * respond, and awaiting it would hang plugin init (and with it the whole
+ * opencode bootstrap).
+ */
+const TOAST_TIMEOUT_MS = 2_000
+
 export async function showToast(
   client: PluginInput["client"],
   message: string,
   logger: Logger
 ): Promise<void> {
   try {
-    await client.tui.showToast({
-      throwOnError: true,
-      body: {
-        title: TOAST_TITLE,
-        message,
-        variant: toastVariant(message),
-        duration: toastDuration(message),
-      },
-    })
+    if (!client.tui?.showToast) return
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        client.tui.showToast({
+          throwOnError: true,
+          body: {
+            title: TOAST_TITLE,
+            message,
+            variant: toastVariant(message),
+            duration: toastDuration(message),
+          },
+        }),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error("toast timed out (no TUI attached)")), TOAST_TIMEOUT_MS)
+          timer.unref?.()
+        }),
+      ])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
   } catch (error) {
     await logger("debug", "toast unavailable", { error: errorMessage(error) })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,8 @@ export const PeersPlugin: Plugin = async (ctx, pluginOptions) => {
   // Resolve name conflicts before announcing ourselves.
   const unique = uniqueName(currentName, await registry.list())
   if (unique.changed) {
-    await showToast(
+    // Fire-and-forget: plugin init must never block on UX feedback.
+    void showToast(
       ctx.client,
       `📋 Name "${currentName}" was taken; this instance is "${unique.name}".`,
       logger

--- a/tests/tracker-feedback.test.mjs
+++ b/tests/tracker-feedback.test.mjs
@@ -57,3 +57,33 @@ test("consumeCommand embeds result message when provided", () => {
   assert.match(parts[0].text, /verbatim/)
   assert.match(parts[0].text, /📋 result here/)
 })
+
+test("showToast resolves when the TUI endpoint never responds (headless hang guard)", async () => {
+  const { showToast } = await import("../dist/feedback.js")
+  const client = {
+    tui: {
+      showToast: () =>
+        new Promise((resolve) => {
+          const t = setTimeout(resolve, 60_000)
+          t.unref?.()
+        }), // effectively never settles, like no-TUI /tui
+    },
+  }
+  const logs = []
+  const logger = async (level, message, extra) => logs.push({ level, message, extra })
+  // Ref'd handle: the toast timeout timer is intentionally unref'd, so a
+  // bare test process needs other work to keep its event loop alive.
+  const keepAlive = setTimeout(() => {}, 5_000)
+  const start = Date.now()
+  await showToast(client, "📋 test", logger)
+  clearTimeout(keepAlive)
+  const elapsed = Date.now() - start
+  assert.ok(elapsed < 5_000, `showToast blocked for ${elapsed}ms`)
+  assert.equal(logs.at(-1)?.level, "debug")
+})
+
+test("showToast is a no-op when client.tui is missing", async () => {
+  const { showToast } = await import("../dist/feedback.js")
+  const logger = async () => {}
+  await showToast({}, "📋 test", logger)
+})


### PR DESCRIPTION
## Summary

- **Root cause**: with no TUI attached (headless `opencode run`, or the TUI not yet connected during bootstrap), the `/tui` showToast endpoint never responds. `PeersPlugin` init `await`ed that toast in the name-conflict branch, so plugin init hung → opencode bootstrap hung → **opencode could not open at all** in any directory whose basename was already registered by another live instance (e.g. a long-running home-dir instance blocks every new home-dir launch).
- `feedback.showToast` now races the SDK call against a 2s unref'd timeout and no-ops when `client.tui` is missing.
- The init-time rename toast is now fire-and-forget; plugin init never blocks on UX feedback.
- Tests: +2 (never-resolving TUI endpoint hang guard; missing `client.tui` no-op).

## Verification

- `npm test`: 44/44 green.
- Real opencode E2E: live instance registered peer name `wangshuai`; new instance in `/Users/wangshuai` hung at bootstrap before the fix (no output after 25s), boots fully after it (`peers started name=wangshuai-2`, TUI renders, `opencode run` completes).
