### PR TITLE
chore: sync PLUGIN_VERSION constant with package version (0.1.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-plugin-peers",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Cross-session messaging for opencode — let independent sessions discover and text each other, modeled after Claude Code's cross-session messaging",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { handlePeersCommand } from "./commands.js"
 import { consumeCommand, createLogger, errorMessage, showToast } from "./feedback.js"
 import type { InboundPolicy, PluginConfig, ReceiveStatus } from "./types.js"
 
-const PLUGIN_VERSION = "0.1.1"
+const PLUGIN_VERSION = "0.1.3"
 const COMMAND_NAMES = new Set(["peers", "list-agents", "peers-name", "peers-inbox"])
 
 export const PeersPlugin: Plugin = async (ctx, pluginOptions) => {


### PR DESCRIPTION
v0.1.2 发布时 src/index.ts 内硬编码的 PLUGIN_VERSION 仍为 0.1.1（仅用于 peers.d 注册表元信息）。本 PR 将常量与 package.json 对齐，并以 0.1.3 发布，保持 npm / main / 注册表元信息一致。npm test 44/44 全绿。