### PR TITLE
fix: single-Enter slash commands on the home route (0.1.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Requires opencode >= 1.18.0.
 
 Without this everything still works — the commands just keep opencode's default "first Enter inserts `/name `, second Enter submits" behavior. Notes:
 
-- The autocomplete keeps showing a **single** `/peers*` row per command (the server-defined one). Instant execution comes from a high-priority Enter binding in the TUI entry: when the prompt holds exactly a plugin command — or a prefix that uniquely identifies it, like `/peers-nam` — Enter runs it immediately; anything else falls through to opencode's stock bindings untouched.
+- The autocomplete keeps showing a **single** `/peers*` row per command (the server-defined one). Instant execution comes from a high-priority Enter binding in the TUI entry: when the prompt holds exactly a plugin command — or a prefix that uniquely identifies it, like `/peers-nam` — Enter runs it immediately; anything else falls through to opencode's stock bindings untouched. This works both inside a session and on the start (home) screen — there a session is created first, exactly like a normal submit.
 - Commands typed **with arguments** (e.g. `/peers-name frontend`) are untouched — Enter submits normally and the argument is preserved.
 - Older opencode versions ignore the TUI entry entirely and keep the two-Enter behavior.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-plugin-peers",
-  "version": "0.1.6",
-  "description": "Cross-session messaging for opencode — let independent sessions discover and text each other, modeled after Claude Code's cross-session messaging",
+  "version": "0.1.7",
+  "description": "Cross-session messaging for opencode \u2014 let independent sessions discover and text each other, modeled after Claude Code's cross-session messaging",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ import { handlePeersCommand } from "./commands.js"
 import { consumeCommand, createLogger, errorMessage } from "./feedback.js"
 import type { InboundPolicy, PluginConfig, ReceiveStatus } from "./types.js"
 
-const PLUGIN_VERSION = "0.1.6"
+const PLUGIN_VERSION = "0.1.7"
 const COMMAND_NAMES = new Set(["peers", "list-agents", "peers-name", "peers-inbox"])
 
 export const PeersPlugin: Plugin = async (ctx, pluginOptions) => {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -15,10 +15,11 @@ import type { TuiPluginApi, TuiPluginModule } from "@opencode-ai/plugin/tui"
  *     focused prompt's text. When it is exactly one of our slash commands
  *     (no arguments), the handler executes it via `client.session.command`
  *     — the same `command.execute.before` interception as a normal submit —
- *     and reports the key handled. For any other text it returns `false`,
- *     and the keymap falls through to the normal bindings
- *     (autocomplete select / input submit), so every other keypress behaves
- *     exactly as stock.
+ *     and reports the key handled. On the home route (no session yet) it
+ *     first creates a session and navigates to it, replicating the stock
+ *     home-submit flow. For any other text it returns `false`, and the
+ *     keymap falls through to the normal bindings (autocomplete select /
+ *     input submit), so every other keypress behaves exactly as stock.
  *
  * Commands typed WITH arguments (e.g. `/peers-name foo`) never match the
  * exact-text check, so they submit normally with the argument intact.
@@ -100,15 +101,20 @@ function resolveTyped(text: string): string | null {
 
 async function runCommand(api: TuiPluginApi, command: string): Promise<void> {
   const route = api.route.current
-  const sessionID =
+  let sessionID =
     route.name === "session"
       ? (route.params as { sessionID?: string } | undefined)?.sessionID
       : undefined
-  if (!sessionID) {
-    api.ui.toast({ variant: "info", title: "opencode-plugin-peers", message: `/${command}: open a session first` })
-    return
-  }
   try {
+    if (!sessionID) {
+      // Home route: replicate the stock submit flow — create a session,
+      // switch to it, then run the command there. Server defaults apply
+      // for agent/model; our commands are consumed before any model call.
+      const res = await api.client.session.create()
+      sessionID = (res as { data?: { id?: string } }).data?.id
+      if (!sessionID) throw new Error("session.create returned no session id")
+      api.route.navigate("session", { sessionID })
+    }
     await api.client.session.command({ sessionID, command, arguments: "" })
   } catch (err) {
     api.ui.toast({
@@ -129,7 +135,9 @@ function onEnter(api: TuiPluginApi, ctx: { focused: unknown }): boolean {
   // Never hijack Enter inside dialogs (rename prompts, palette search, …).
   if (api.ui.dialog.open) return false
   const route = api.route.current
-  if (route.name !== "session") return false
+  // Only the session prompt and the home prompt are command-entry points;
+  // plugin routes and anything else keep stock behavior.
+  if (route.name !== "session" && route.name !== "home") return false
   const focused = ctx.focused as FocusedText | null
   if (typeof focused?.plainText !== "string") return false
   if (Date.now() - otherNamesAt > 60_000) void refreshOtherNames(api)

--- a/tests/tui.test.mjs
+++ b/tests/tui.test.mjs
@@ -9,8 +9,12 @@ function makeApi(over = {}) {
   const toasts = []
   const disposers = []
   let unregister
+  const navigate = (name, params) => calls.push({ kind: "navigate", name, params })
   const api = {
-    route: { current: { name: "session", params: { sessionID: "ses_1" } } },
+    route: {
+      current: { name: "session", params: { sessionID: "ses_1" } },
+      navigate,
+    },
     keymap: {
       registerLayer: (layer) => {
         calls.push({ kind: "registerLayer", layer })
@@ -30,6 +34,11 @@ function makeApi(over = {}) {
         }),
       },
       session: {
+        create: async () => {
+          calls.push({ kind: "create" })
+          if (over.failCreate) throw new Error("create failed")
+          return { data: { id: "ses_created" } }
+        },
         command: async (args) => {
           calls.push({ kind: "command", args })
           if (over.failCommand) throw new Error("server unreachable")
@@ -41,7 +50,9 @@ function makeApi(over = {}) {
       dialog: { open: over.dialogOpen ?? false },
     },
     lifecycle: { onDispose: (fn) => disposers.push(fn) },
-    ...("route" in over ? { route: over.route } : {}),
+    ...("route" in over
+      ? { route: { current: over.route.current, navigate } }
+      : {}),
   }
   api.keymap.getCommandEntries = () => [
     { command: { name: "session.new", slashName: "new" } },
@@ -160,16 +171,35 @@ test("Enter binding rejects everything else so stock behavior is untouched", asy
   assert.equal(calls.filter((c) => c.kind === "command").length, 0)
 })
 
-test("Enter binding rejects inside dialogs and outside session routes", async () => {
+test("Enter on the home route creates a session, navigates, and executes", async () => {
+  const { api, calls } = makeApi({ route: { current: { name: "home" } } })
+  await mod.tui(api)
+  const binding = calls[0].layer.bindings[0]
+  const focused = makeFocused("/peers")
+  assert.equal(binding.cmd({ focused }), true)
+  assert.equal(focused.plainText, "")
+  await new Promise((r) => setImmediate(r))
+  await new Promise((r) => setImmediate(r))
+  assert.deepEqual(
+    calls.filter((c) => ["create", "navigate", "command"].includes(c.kind)),
+    [
+      { kind: "create" },
+      { kind: "navigate", name: "session", params: { sessionID: "ses_created" } },
+      { kind: "command", args: { sessionID: "ses_created", command: "peers", arguments: "" } },
+    ],
+  )
+})
+
+test("Enter binding rejects inside dialogs and on plugin routes", async () => {
   const dialogApi = makeApi({ dialogOpen: true })
   await mod.tui(dialogApi.api)
   const dialogBinding = dialogApi.calls[0].layer.bindings[0]
   assert.equal(dialogBinding.cmd({ focused: makeFocused("/peers") }), false)
 
-  const homeApi = makeApi({ route: { current: { name: "home" } } })
-  await mod.tui(homeApi.api)
-  const homeBinding = homeApi.calls[0].layer.bindings[0]
-  assert.equal(homeBinding.cmd({ focused: makeFocused("/peers") }), false)
+  const pluginApi = makeApi({ route: { current: { name: "some-plugin", params: {} } } })
+  await mod.tui(pluginApi.api)
+  const pluginBinding = pluginApi.calls[0].layer.bindings[0]
+  assert.equal(pluginBinding.cmd({ focused: makeFocused("/peers") }), false)
 })
 
 test("layer priority outranks the autocomplete select binding", async () => {
@@ -178,15 +208,31 @@ test("layer priority outranks the autocomplete select binding", async () => {
   assert.ok(calls[0].layer.priority > 1) // TUI built-ins use 0..1
 })
 
-test("run() outside a session toasts and does not call the server", async () => {
-  const { api, calls, toasts } = makeApi({ route: { current: { name: "home" } } })
+test("run() on the home route creates a session and executes there", async () => {
+  const { api, calls } = makeApi({ route: { current: { name: "home" } } })
   await mod.tui(api)
   const peers = calls[0].layer.commands.find((c) => c.name === "opencode-plugin-peers.peers")
   await peers.run()
+  assert.deepEqual(
+    calls.filter((c) => ["create", "navigate", "command"].includes(c.kind)),
+    [
+      { kind: "create" },
+      { kind: "navigate", name: "session", params: { sessionID: "ses_created" } },
+      { kind: "command", args: { sessionID: "ses_created", command: "peers", arguments: "" } },
+    ],
+  )
+})
+
+test("session.create failure surfaces an error toast and does not navigate", async () => {
+  const { api, calls, toasts } = makeApi({ route: { current: { name: "home" } }, failCreate: true })
+  await mod.tui(api)
+  const peers = calls[0].layer.commands.find((c) => c.name === "opencode-plugin-peers.peers")
+  await peers.run()
+  assert.equal(calls.filter((c) => c.kind === "navigate").length, 0)
   assert.equal(calls.filter((c) => c.kind === "command").length, 0)
   assert.equal(toasts.length, 1)
-  assert.equal(toasts[0].variant, "info")
-  assert.match(toasts[0].message, /open a session first/)
+  assert.equal(toasts[0].variant, "error")
+  assert.match(toasts[0].message, /create failed/)
 })
 
 test("server failure surfaces an error toast and does not throw", async () => {


### PR DESCRIPTION
## 问题

启动 `opencode` 后停留在主(home)界面时,输入 `/peers` 等命令按回车只插入 `/peers `(加空格),需要第二次回车才执行。会话内(`opencode -c`)则正常。

## 根因

`onEnter` 的路由守卫 `route.name !== "session" → return false`:home 路由上我们的 priority-10 Enter 绑定直接放行,第一下回车落到 autocomplete 的 insert-text 选择上。而原生 `submitInner` 在 autocomplete 可见时 `return false`,所以必须第二下回车才提交。

## 修复

home 路由也拦截;无 sessionID 时 `runCommand` 复刻原生 home 提交流程:`client.session.create()` → `route.navigate("session", { sessionID })` → `session.command()`。palette 命令在 home 路由触发时走同一路径(原来的 "open a session first" toast 移除)。

## 验证

- `npm test`:72/72 全绿(新增:home 路由 Enter → create+navigate+command 顺序断言;palette run() home 路由;session.create 失败 → error toast 且不 navigate;路由覆盖守卫改为 plugin 路由)
- 真实 TUI E2E(file:// 本地构建,配置备份/恢复):
  1. **home 路由** 精确 `/peers` + 单次回车 → 命令执行 ✅(修复前复现:单次回车仅插入文本,二次回车才执行)
  2. **会话内**(`-c`)精确 `/peers` + 单次回车 → 执行 ✅
  3. **会话内** 前缀 `/peers-nam` + 单次回车 → 单行补全 + 执行 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)