### PR TITLE
docs: record the packages/<name>@latest cache gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,4 +35,5 @@ Cross-session messaging plugin for opencode: independent instances on the same m
 - `session.idle` is not guaranteed on every opencode version — keep the fallback sweep.
 - `opencode serve` loads plugins lazily: create a session first before expecting registration.
 - When spawning background `opencode serve` processes from scripts, detach stdio (`nohup ... &` inside a subshell) or the parent hangs on the inherited pipe.
+- Local upgrades: a bare plugin spec resolves via `Npm.add("<name>@latest")` to `~/.cache/opencode/packages/<name>@latest/`, and `opencode plugin -g <name>` does NOT refresh it — after publishing a new version, update that dir's pin + `npm install` (and `<name>/` if present too), or the runtime keeps loading the stale copy.
 - TUI E2E harness: drive the TUI with `( sleep N; printf '/cmd'; sleep 2; printf '\r'; sleep M ) | script -q /tmp/out opencode -c --print-logs`. macOS BSD `script` hangs after the input pipe EOFs until the child is killed — `pkill` the TUI from **outside** the pipeline (a pkill after the pipe in the same script never runs).


### PR DESCRIPTION
本地升级验证时发现的坑：裸 spec 经 `Npm.add("<name>@latest")` 解析到 `~/.cache/opencode/packages/<name>@latest/`，`opencode plugin -g` 不会刷新它——发布新版后运行时会继续加载旧副本（本次 0.1.7 验证一度 FAIL 就是因为 @latest 目录仍是 0.1.6）。记入 CLAUDE.md Gotchas。

🤖 Generated with [Claude Code](https://claude.com/claude-code)