### PR TITLE
chore: move CLAUDE.md exclusion to local .git/info/exclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 dist/
 *.tsbuildinfo
 .DS_Store
-CLAUDE.md


### PR DESCRIPTION
## What

- Remove `CLAUDE.md` from the shared `.gitignore`.
- The exclusion now lives in the **local-only** `.git/info/exclude` (not tracked, not pushed).

## Why

`CLAUDE.md` is a personal, machine-local instructions file. Its git exclusion should be local configuration, not a shared repo rule.

## Verification

- `git check-ignore CLAUDE.md` → still ignored (via `.git/info/exclude`).
- `git status` → clean (CLAUDE.md does not appear as untracked).
- `git ls-files CLAUDE.md` → empty (not tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)